### PR TITLE
Handle deposit remainder and add test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ obj/
 .env
 .env.local
 node_modules/
+lib/
+out/
+cache/
 __pycache__/

--- a/SmartContracts/MockERC20.sol
+++ b/SmartContracts/MockERC20.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor() ERC20("MockToken", "MOCK") {
+        _mint(msg.sender, 1e27);
+    }
+}

--- a/SmartContracts/OfflineEscrowContract.sol
+++ b/SmartContracts/OfflineEscrowContract.sol
@@ -27,10 +27,15 @@ contract OfflineEscrowContract {
     function deposit(uint256 amount, bytes[] calldata serials) external {
         require(jpyc.transferFrom(msg.sender, address(this), amount), "transfer failed");
         uint256 per = amount / serials.length;
+        uint256 remainder = amount % serials.length;
         uint256 expiry = block.timestamp + 7 days;
         for (uint i=0; i<serials.length; i++) {
-            opts[serials[i]] = OPT(serials[i], per, expiry, false);
-            emit Issued(serials[i], per, expiry);
+            uint256 amt = per;
+            if (i == 0) {
+                amt += remainder;
+            }
+            opts[serials[i]] = OPT(serials[i], amt, expiry, false);
+            emit Issued(serials[i], amt, expiry);
         }
     }
 

--- a/contracts/MockERC20.sol
+++ b/contracts/MockERC20.sol
@@ -1,0 +1,1 @@
+../SmartContracts/MockERC20.sol

--- a/contracts/OfflineEscrowContract.sol
+++ b/contracts/OfflineEscrowContract.sol
@@ -1,0 +1,1 @@
+../SmartContracts/OfflineEscrowContract.sol

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,9 @@
+[profile.default]
+src = "contracts"
+out = "out"
+libs = ["lib"]
+
+remappings = [
+    "@openzeppelin/=lib/openzeppelin-contracts/",
+    "@account-abstraction/=lib/account-abstraction/contracts/"
+]

--- a/test/Deposit.t.sol
+++ b/test/Deposit.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/OfflineEscrowContract.sol";
+import "../contracts/MockERC20.sol";
+
+contract DepositTest is Test {
+    OfflineEscrowContract escrow;
+    MockERC20 token;
+
+    function setUp() public {
+        token = new MockERC20();
+        escrow = new OfflineEscrowContract(address(token));
+    }
+
+    function testRemainderToFirstSerial() public {
+        bytes[] memory serials = new bytes[](3);
+        serials[0] = "\x01";
+        serials[1] = "\x02";
+        serials[2] = "\x03";
+        token.approve(address(escrow), 1000);
+        escrow.deposit(1000, serials);
+        (bytes memory s0,uint256 a0,,) = escrow.opts(serials[0]);
+        (,uint256 a1,,) = escrow.opts(serials[1]);
+        (,uint256 a2,,) = escrow.opts(serials[2]);
+        assertEq(a0, 334);
+        assertEq(a1, 333);
+        assertEq(a2, 333);
+    }
+}


### PR DESCRIPTION
## Summary
- distribute remainder to the first serial when depositing
- add MockERC20 test token
- add Forge test covering uneven deposits
- ignore build artifacts

## Testing
- `forge test -vvv`

------
https://chatgpt.com/codex/tasks/task_e_6842e26f47a88320af4f9f418bb95087