### PR TITLE
Implement redeem backend

### DIFF
--- a/Backend/OfflineSyncFunction/OfflineSyncFunction.csproj
+++ b/Backend/OfflineSyncFunction/OfflineSyncFunction.csproj
@@ -10,6 +10,12 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.15.1" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.0" />
     <PackageReference Include="Nethereum.Web3" Version="4.3.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.32.1" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.16.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\RedeemBundle.cs" Link="RedeemBundle.cs" />
   </ItemGroup>
 
 </Project>

--- a/Backend/OfflineSyncFunction/RedeemBundleApi.cs
+++ b/Backend/OfflineSyncFunction/RedeemBundleApi.cs
@@ -1,16 +1,40 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
 using System.Text.Json;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Azure.Cosmos;
+using Azure.Storage.Queues;
+using Microsoft.IdentityModel.Tokens;
+using Backend.Shared;
 
 namespace OfflineSyncFunction;
 
 public class RedeemBundleApi
 {
     private readonly ILogger _logger;
+    private readonly CosmosClient _cosmos;
+    private readonly QueueClient _queue;
+    private readonly TokenValidationParameters _tokenParams;
+
     public RedeemBundleApi(ILoggerFactory loggerFactory)
     {
         _logger = loggerFactory.CreateLogger<RedeemBundleApi>();
+        _cosmos = new CosmosClient(Environment.GetEnvironmentVariable("COSMOS_CONNECTION")!);
+        _queue = new QueueClient(
+            Environment.GetEnvironmentVariable("QUEUE_CONNECTION"),
+            Environment.GetEnvironmentVariable("QUEUE_NAME") ?? "redeem-bundles");
+        _queue.CreateIfNotExists();
+
+        var key = Environment.GetEnvironmentVariable("JWT_SIGNING_KEY") ?? "secret";
+        _tokenParams = new TokenValidationParameters
+        {
+            ValidateIssuer = false,
+            ValidateAudience = false,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(key))
+        };
     }
 
     [Function("RedeemBundle")]
@@ -19,9 +43,36 @@ public class RedeemBundleApi
     {
         var body = await new StreamReader(req.Body).ReadToEndAsync();
         _logger.LogInformation("Received redeem bundle");
-        // TODO: validate JWT, write to Cosmos, enqueue durable orchestration
+
+        if (!req.Headers.TryGetValues("Authorization", out var authHeaders))
+            return req.CreateResponse(System.Net.HttpStatusCode.Unauthorized);
+        var bearer = authHeaders.FirstOrDefault()?.Split(' ').Last();
+        if (string.IsNullOrEmpty(bearer))
+            return req.CreateResponse(System.Net.HttpStatusCode.Unauthorized);
+
+        var handler = new JwtSecurityTokenHandler();
+        try
+        {
+            handler.ValidateToken(bearer, _tokenParams, out _);
+        }
+        catch
+        {
+            return req.CreateResponse(System.Net.HttpStatusCode.Unauthorized);
+        }
+
+        var bundle = JsonSerializer.Deserialize<RedeemBundle>(body);
+        if (bundle == null)
+            return req.CreateResponse(System.Net.HttpStatusCode.BadRequest);
+
+        var db = Environment.GetEnvironmentVariable("BUNDLE_DB_NAME") ?? "offline";
+        var containerName = Environment.GetEnvironmentVariable("BUNDLE_CONTAINER_NAME") ?? "bundles";
+        var container = _cosmos.GetContainer(db, containerName);
+        await container.CreateItemAsync(bundle);
+
+        await _queue.SendMessageAsync(bundle.id);
+
         var res = req.CreateResponse(System.Net.HttpStatusCode.Accepted);
-        await res.WriteStringAsync("{"status":"accepted"}");
+        await res.WriteStringAsync("{\"status\":\"accepted\"}");
         return res;
     }
 }

--- a/Backend/RedeemFunction/RedeemFunction.csproj
+++ b/Backend/RedeemFunction/RedeemFunction.csproj
@@ -8,6 +8,12 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.17.0" />
     <PackageReference Include="Nethereum.Web3" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.16.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\RedeemBundle.cs" Link="RedeemBundle.cs" />
   </ItemGroup>
 
 </Project>

--- a/Backend/RedeemFunction/RedeemOrchestrator.cs
+++ b/Backend/RedeemFunction/RedeemOrchestrator.cs
@@ -1,23 +1,72 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Nethereum.Web3;
+using Nethereum.Web3.Accounts;
+using Azure.Storage.Queues;
+using Microsoft.Azure.Cosmos;
+using Backend.Shared;
 
 namespace RedeemFunction;
 
 public class RedeemOrchestrator
 {
     private readonly ILogger _logger;
-    private readonly Web3 _web3 = new("https://polygon-rpc.com");
+    private readonly Web3 _web3;
+    private readonly CosmosClient _cosmos;
+    private readonly QueueClient _queue;
+    private readonly string _contract;
+    private readonly string _db;
+    private readonly string _container;
 
     public RedeemOrchestrator(ILoggerFactory loggerFactory)
     {
         _logger = loggerFactory.CreateLogger<RedeemOrchestrator>();
+        var rpc = Environment.GetEnvironmentVariable("RPC_URL") ?? "https://polygon-rpc.com";
+        var pk = Environment.GetEnvironmentVariable("PRIVATE_KEY") ?? "";
+        _web3 = string.IsNullOrEmpty(pk) ? new Web3(rpc) : new Web3(new Account(pk), rpc);
+        _cosmos = new CosmosClient(Environment.GetEnvironmentVariable("COSMOS_CONNECTION")!);
+        _queue = new QueueClient(
+            Environment.GetEnvironmentVariable("QUEUE_CONNECTION"),
+            Environment.GetEnvironmentVariable("QUEUE_NAME") ?? "redeem-bundles");
+        _contract = Environment.GetEnvironmentVariable("CONTRACT_ADDRESS") ?? "0x";
+        _db = Environment.GetEnvironmentVariable("BUNDLE_DB_NAME") ?? "offline";
+        _container = Environment.GetEnvironmentVariable("BUNDLE_CONTAINER_NAME") ?? "bundles";
     }
 
     [Function("RedeemExecutor")]
     public async Task Run([TimerTrigger("0 */5 * * * *")] TimerInfo timer)
     {
         _logger.LogInformation("RedeemExecutor fired at {time}", DateTime.UtcNow);
-        // TODO: fetch pending bundles, call smart contract
+
+        if (!await _queue.ExistsAsync()) return;
+        var msgs = await _queue.ReceiveMessagesAsync(32);
+        foreach (var msg in msgs.Value)
+        {
+            var id = msg.Body.ToString();
+            try
+            {
+                var container = _cosmos.GetContainer(_db, _container);
+                var response = await container.ReadItemAsync<RedeemBundle>(id, new PartitionKey(id));
+                var bundle = response.Resource;
+                if (bundle.processed)
+                {
+                    await _queue.DeleteMessageAsync(msg.MessageId, msg.PopReceipt);
+                    continue;
+                }
+
+                var abi = "[{\"inputs\":[{\"internalType\":\"bytes[]\",\"name\":\"serials\",\"type\":\"bytes[]\"}],\"name\":\"redeemBundle\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]";
+                var contract = _web3.Eth.GetContract(abi, _contract);
+                var func = contract.GetFunction("redeemBundle");
+                await func.SendTransactionAsync(_web3.TransactionManager.Account?.Address, new object[] { bundle.serials });
+
+                bundle.processed = true;
+                await container.ReplaceItemAsync(bundle, bundle.id);
+                await _queue.DeleteMessageAsync(msg.MessageId, msg.PopReceipt);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to process bundle {id}", id);
+            }
+        }
     }
 }

--- a/Backend/Shared/RedeemBundle.cs
+++ b/Backend/Shared/RedeemBundle.cs
@@ -1,0 +1,10 @@
+namespace Backend.Shared;
+
+public class RedeemBundle
+{
+    // Cosmos DB uses 'id' as the primary key
+    public string id { get; set; } = Guid.NewGuid().ToString();
+    public string[] serials { get; set; } = Array.Empty<string>();
+    public bool processed { get; set; } = false;
+}
+

--- a/README.md
+++ b/README.md
@@ -33,3 +33,23 @@ forge build
 ```
 
 > See **docs/architecture.md** for more detail.
+
+## Configuration Sample
+
+Set the following environment variables before running the Azure Functions:
+
+```bash
+COSMOS_CONNECTION="AccountEndpoint=https://<acc>.documents.azure.com:443/;AccountKey=<key>"
+BUNDLE_DB_NAME="offline"
+BUNDLE_CONTAINER_NAME="bundles"
+QUEUE_CONNECTION="DefaultEndpointsProtocol=https;AccountName=<storage>;AccountKey=<key>;EndpointSuffix=core.windows.net"
+QUEUE_NAME="redeem-bundles"
+JWT_SIGNING_KEY="secret"
+RPC_URL="https://polygon-rpc.com"
+CONTRACT_ADDRESS="0xabcdef1234567890"
+PRIVATE_KEY="0x012345..."
+```
+
+These values configure Cosmos DB, the storage queue and Polygon contract used by
+`RedeemBundleApi` and `RedeemOrchestrator`.
+


### PR DESCRIPTION
## Summary
- implement RedeemBundle model shared by functions
- implement RedeemBundleApi with JWT validation, Cosmos write and queue enqueue
- implement RedeemOrchestrator to dequeue bundles and call redeem contract via Nethereum
- add configuration sample to README
- update csproj with required packages

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e26c26308320b221f1f57ff9ff30