### PR TITLE
Implement biometric and passkey auth service

### DIFF
--- a/MobileApp/MauiProgram.cs
+++ b/MobileApp/MauiProgram.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using JPYCOffline.Services;
 
 namespace JPYCOffline;
 
@@ -14,6 +15,8 @@ public static class MauiProgram
                 fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                 fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
             });
+
+        builder.Services.AddSingleton<IAuthenticatorService, AuthenticatorService>();
 
 #if DEBUG
         builder.Logging.AddDebug();

--- a/MobileApp/MobileApp.csproj
+++ b/MobileApp/MobileApp.csproj
@@ -32,5 +32,7 @@
 
     <!-- BouncyCastle をバージョン固定して警告解消 -->
     <PackageReference Update="Portable.BouncyCastle" Version="1.8.10" />
+    <!-- Biometric authentication -->
+    <PackageReference Include="Xamarin.Google.AndroidX.Biometric" Version="1.1.0.9" />
   </ItemGroup>
 </Project>

--- a/MobileApp/Services/AuthenticatorService.cs
+++ b/MobileApp/Services/AuthenticatorService.cs
@@ -1,0 +1,75 @@
+#if ANDROID
+using AndroidX.Biometric;
+using AndroidX.Core.Content;
+using Java.Lang;
+using Microsoft.Maui.ApplicationModel;
+#endif
+#if IOS
+using LocalAuthentication;
+using Foundation;
+#endif
+using Microsoft.Maui.Authentication;
+
+namespace JPYCOffline.Services;
+
+public class AuthenticatorService : IAuthenticatorService
+{
+    public async Task<bool> AuthenticateAsync()
+    {
+#if ANDROID
+        var activity = Platform.CurrentActivity ?? throw new InvalidOperationException("No current activity");
+        var executor = ContextCompat.GetMainExecutor(activity);
+        var tcs = new TaskCompletionSource<bool>();
+        var callback = new AuthenticationCallback(tcs);
+        var promptInfo = new BiometricPrompt.PromptInfo.Builder()
+            .SetTitle("Authenticate")
+            .SetSubtitle("Verify your identity")
+            .SetNegativeButtonText("Cancel")
+            .Build();
+        var prompt = new BiometricPrompt(activity, executor, callback);
+        prompt.Authenticate(promptInfo);
+        return await tcs.Task;
+#elif IOS
+        var context = new LAContext();
+        var result = await context.EvaluatePolicyAsync(LAPolicy.DeviceOwnerAuthenticationWithBiometrics, "Authenticate to continue");
+        return result.Item1;
+#else
+        return await AuthenticateWithPasskeyAsync();
+#endif
+    }
+
+    public async Task<bool> AuthenticateWithPasskeyAsync()
+    {
+        try
+        {
+            var result = await WebAuthenticator.AuthenticateAsync(new Uri("https://example.com/passkey"), new Uri("mauiapp://callback"));
+            return result is not null;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+#if ANDROID
+    class AuthenticationCallback : BiometricPrompt.AuthenticationCallback
+    {
+        readonly TaskCompletionSource<bool> _tcs;
+        public AuthenticationCallback(TaskCompletionSource<bool> tcs) => _tcs = tcs;
+        public override void OnAuthenticationSucceeded(BiometricPrompt.AuthenticationResult result)
+        {
+            base.OnAuthenticationSucceeded(result);
+            _tcs.TrySetResult(true);
+        }
+        public override void OnAuthenticationError(int errorCode, ICharSequence errString)
+        {
+            base.OnAuthenticationError(errorCode, errString);
+            _tcs.TrySetResult(false);
+        }
+        public override void OnAuthenticationFailed()
+        {
+            base.OnAuthenticationFailed();
+        }
+    }
+#endif
+}

--- a/MobileApp/Services/IAuthenticatorService.cs
+++ b/MobileApp/Services/IAuthenticatorService.cs
@@ -3,4 +3,5 @@ namespace JPYCOffline.Services;
 public interface IAuthenticatorService
 {
     Task<bool> AuthenticateAsync();
+    Task<bool> AuthenticateWithPasskeyAsync();
 }


### PR DESCRIPTION
## Summary
- add `AuthenticatorService` with Android/iOS implementations and passkey support
- register `IAuthenticatorService` in `MauiProgram`
- add Android biometric package
- expose `AuthenticateWithPasskeyAsync` in interface

## Testing
- `dotnet build MobileApp/MobileApp.csproj -t:Restore -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e75b750883208a97ad90efe42783