### PR TITLE
Remove duplicate AuthenticateAsync method

### DIFF
--- a/MobileApp/Services/AuthenticatorService.cs
+++ b/MobileApp/Services/AuthenticatorService.cs
@@ -37,7 +37,6 @@ public class AuthenticatorService : IAuthenticatorService
 
     string Key(string issuer, string account) => $"{issuer}:{account}";
 
-    public Task<bool> AuthenticateAsync() => Task.FromResult(true);
 
     public async Task AddAccountAsync(string issuer, string accountName, string secret)
     {


### PR DESCRIPTION
## Summary
- remove redundant `AuthenticateAsync` implementation from `AuthenticatorService`

## Testing
- `dotnet build stable_transaction.sln --nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438a429f208320807f99aa00064d9a