### PR TITLE
Switch TOTP generation to async API

### DIFF
--- a/MobileApp/Pages/AuthenticatorAccounts.razor
+++ b/MobileApp/Pages/AuthenticatorAccounts.razor
@@ -38,12 +38,16 @@
     async Task LoadAsync()
     {
         var accts = await Auth.GetAccountsAsync();
-        _accounts = accts.Select(a => new AccountItem
+        _accounts = new List<AccountItem>();
+        foreach (var a in accts)
         {
-            Issuer = a.Issuer,
-            AccountName = a.AccountName,
-            Code = Auth.GenerateTotp(a.Issuer, a.AccountName)
-        }).ToList();
+            _accounts.Add(new AccountItem
+            {
+                Issuer = a.Issuer,
+                AccountName = a.AccountName,
+                Code = await Auth.GenerateTotpAsync(a.Issuer, a.AccountName)
+            });
+        }
     }
 
     void StartScan() => _scanning = true;

--- a/MobileApp/Services/AuthenticatorService.cs
+++ b/MobileApp/Services/AuthenticatorService.cs
@@ -74,9 +74,9 @@ public class AuthenticatorService : IAuthenticatorService
         }).ToList();
     }
 
-    public string GenerateTotp(string issuer, string accountName)
+    public async Task<string> GenerateTotpAsync(string issuer, string accountName)
     {
-        EnsureLoadedAsync().GetAwaiter().GetResult();
+        await EnsureLoadedAsync();
         if (!_accounts.TryGetValue(Key(issuer, accountName), out var secret))
             throw new InvalidOperationException("Account not found");
         var totp = new Totp(Base32Encoding.ToBytes(secret));

--- a/MobileApp/Services/IAuthenticatorService.cs
+++ b/MobileApp/Services/IAuthenticatorService.cs
@@ -12,5 +12,5 @@ public interface IAuthenticatorService
 
     Task<IReadOnlyList<AuthenticatorAccount>> GetAccountsAsync();
 
-    string GenerateTotp(string issuer, string accountName);
+    Task<string> GenerateTotpAsync(string issuer, string accountName);
 }

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ builder.Services.AddSingleton<IAuthenticatorService, AuthenticatorService>();
 Generate a TOTP code:
 
 ```csharp
-var totp = AuthenticatorService.GenerateTotp("Example", "alice");
+var totp = await AuthenticatorService.GenerateTotpAsync("Example", "alice");
 ```
 
 > See **docs/architecture.md** for more detail.

--- a/Tests/AuthenticatorServiceTests.cs
+++ b/Tests/AuthenticatorServiceTests.cs
@@ -12,7 +12,7 @@ public class AuthenticatorServiceTests
         await service.AddAccountAsync("Test", "alice", "JBSWY3DPEHPK3PXP");
         await service.AddAccountAsync("Test", "bob", "JBSWY3DPEHPK3PXP");
 
-        var code = service.GenerateTotp("Test", "alice");
+        var code = await service.GenerateTotpAsync("Test", "alice");
         Assert.Equal(6, code.Length);
 
         var service2 = new AuthenticatorService(store);


### PR DESCRIPTION
## Summary
- make `GenerateTotp` asynchronous
- await `EnsureLoadedAsync()` instead of blocking
- update the authenticator accounts page, tests and docs

## Testing
- `dotnet test Tests/Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6843c091c594832091406c13b83dbcd9