### PR TITLE
Refactor RedeemBundle model

### DIFF
--- a/Backend/OfflineSyncFunction/RedeemBundleApi.cs
+++ b/Backend/OfflineSyncFunction/RedeemBundleApi.cs
@@ -67,9 +67,9 @@ public class RedeemBundleApi
         var db = Environment.GetEnvironmentVariable("BUNDLE_DB_NAME") ?? "offline";
         var containerName = Environment.GetEnvironmentVariable("BUNDLE_CONTAINER_NAME") ?? "bundles";
         var container = _cosmos.GetContainer(db, containerName);
-        await container.CreateItemAsync(bundle);
+        await container.CreateItemAsync(bundle, new PartitionKey(bundle.Id));
 
-        await _queue.SendMessageAsync(bundle.id);
+        await _queue.SendMessageAsync(bundle.Id);
 
         var res = req.CreateResponse(System.Net.HttpStatusCode.Accepted);
         await res.WriteStringAsync("{\"status\":\"accepted\"}");

--- a/Backend/RedeemFunction/RedeemOrchestrator.cs
+++ b/Backend/RedeemFunction/RedeemOrchestrator.cs
@@ -48,7 +48,7 @@ public class RedeemOrchestrator
                 var container = _cosmos.GetContainer(_db, _container);
                 var response = await container.ReadItemAsync<RedeemBundle>(id, new PartitionKey(id));
                 var bundle = response.Resource;
-                if (bundle.processed)
+                if (bundle.Processed)
                 {
                     await _queue.DeleteMessageAsync(msg.MessageId, msg.PopReceipt);
                     continue;
@@ -57,10 +57,10 @@ public class RedeemOrchestrator
                 var abi = "[{\"inputs\":[{\"internalType\":\"bytes[]\",\"name\":\"serials\",\"type\":\"bytes[]\"}],\"name\":\"redeemBundle\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]";
                 var contract = _web3.Eth.GetContract(abi, _contract);
                 var func = contract.GetFunction("redeemBundle");
-                await func.SendTransactionAsync(_web3.TransactionManager.Account?.Address, new object[] { bundle.serials });
+                await func.SendTransactionAsync(_web3.TransactionManager.Account?.Address, new object[] { bundle.Serials });
 
-                bundle.processed = true;
-                await container.ReplaceItemAsync(bundle, bundle.id);
+                bundle.Processed = true;
+                await container.ReplaceItemAsync(bundle, bundle.Id);
                 await _queue.DeleteMessageAsync(msg.MessageId, msg.PopReceipt);
             }
             catch (Exception ex)

--- a/Backend/Shared/RedeemBundle.cs
+++ b/Backend/Shared/RedeemBundle.cs
@@ -1,10 +1,23 @@
 namespace Backend.Shared;
 
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Represents a bundle of offline tokens to be redeemed on-chain.
+/// </summary>
 public class RedeemBundle
 {
-    // Cosmos DB uses 'id' as the primary key
-    public string id { get; set; } = Guid.NewGuid().ToString();
-    public string[] serials { get; set; } = Array.Empty<string>();
-    public bool processed { get; set; } = false;
+    /// <summary>
+    /// Cosmos DB uses <c>id</c> as the primary key, keep the lower-case name
+    /// through JSON mapping while exposing a PascalCase property.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    [JsonPropertyName("serials")]
+    public string[] Serials { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("processed")]
+    public bool Processed { get; set; } = false;
 }
 


### PR DESCRIPTION
## Summary
- rename RedeemBundle properties using PascalCase
- map JSON names to keep Cosmos DB schema
- update RedeemBundle API and orchestrator to use new properties and pass PartitionKey

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*
- `forge build` *(fails: `forge: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843e929496c83209b926482986ad034