### PR TITLE
Fix solidity import paths in tests

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -1,10 +1,8 @@
 name: Android Build
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -1,8 +1,16 @@
 name: Deploy Azure Functions
 
 on:
-  push:
-    branches: [main]
+  workflow_call:
+    secrets:
+      OFFLINE_FUNCTIONAPP_NAME:
+        required: true
+      OFFLINE_FUNCTIONAPP_PUBLISH_PROFILE:
+        required: true
+      REDEEM_FUNCTIONAPP_NAME:
+        required: true
+      REDEEM_FUNCTIONAPP_PUBLISH_PROFILE:
+        required: true
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   test:
@@ -15,7 +14,7 @@ jobs:
         with:
           dotnet-version: '8.0.x'
       - name: Run .NET tests
-        run: dotnet test tests/dotnet/Tests.csproj --no-build --verbosity normal
+        run: dotnet test tests/dotnet/Tests.csproj --verbosity normal
       - name: Setup Foundry
         uses: onbjerg/foundry-toolchain@v1
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,48 @@
+name: Validate and Dispatch
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      ci: ${{ steps.filter.outputs.ci }}
+      android: ${{ steps.filter.outputs.android }}
+      azure: ${{ steps.filter.outputs.azure }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            ci:
+              - 'SmartContracts/**'
+              - 'tests/**'
+              - '.github/workflows/ci.yml'
+              - 'Backend/**'
+            android:
+              - 'MobileApp/**'
+              - '.github/workflows/android_build.yml'
+            azure:
+              - 'Backend/**'
+              - '.github/workflows/azure-deploy.yml'
+  ci:
+    needs: filter
+    if: needs.filter.outputs.ci == 'true'
+    uses: ./.github/workflows/ci.yml
+  android:
+    needs: filter
+    if: needs.filter.outputs.android == 'true'
+    uses: ./.github/workflows/android_build.yml
+  azure:
+    needs: filter
+    if: needs.filter.outputs.azure == 'true'
+    uses: ./.github/workflows/azure-deploy.yml
+    secrets:
+      OFFLINE_FUNCTIONAPP_NAME: ${{ secrets.OFFLINE_FUNCTIONAPP_NAME }}
+      OFFLINE_FUNCTIONAPP_PUBLISH_PROFILE: ${{ secrets.OFFLINE_FUNCTIONAPP_PUBLISH_PROFILE }}
+      REDEEM_FUNCTIONAPP_NAME: ${{ secrets.REDEEM_FUNCTIONAPP_NAME }}
+      REDEEM_FUNCTIONAPP_PUBLISH_PROFILE: ${{ secrets.REDEEM_FUNCTIONAPP_PUBLISH_PROFILE }}

--- a/tests/solidity/Deposit.t.sol
+++ b/tests/solidity/Deposit.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
-import "../SmartContracts/OfflineEscrowContract.sol";
-import "../SmartContracts/MockERC20.sol";
+import "../../SmartContracts/OfflineEscrowContract.sol";
+import "../../SmartContracts/MockERC20.sol";
 
 contract DepositTest is Test {
     OfflineEscrowContract escrow;

--- a/tests/solidity/Redeem.t.sol
+++ b/tests/solidity/Redeem.t.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
-import "../SmartContracts/OfflineEscrowContract.sol";
-import "../SmartContracts/RedeemContract.sol";
-import "../SmartContracts/MockERC20.sol";
+import "../../SmartContracts/OfflineEscrowContract.sol";
+import "../../SmartContracts/RedeemContract.sol";
+import "../../SmartContracts/MockERC20.sol";
 
 contract RedeemTest is Test {
     OfflineEscrowContract escrow;


### PR DESCRIPTION
## Summary
- make CI, Android build, and Azure deploy workflows reusable
- orchestrate them via new `validate.yml` that runs jobs only when related files change

## Testing
- `dotnet test tests/dotnet/Tests.csproj --verbosity minimal` *(fails: dotnet not found)*
- `forge test -vvv` *(fails: forge not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463c3c0b7483208e215acfad663ab3