### PR TITLE
Align mobile build with .NET 8

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -14,27 +14,27 @@ jobs:
     - name: Setup .NET MAUI
       uses: weslleymurdock/setup-maui-action@v1.1
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Restore dependencies
       run: dotnet restore MobileApp/MobileApp.csproj
 
     - name: Build Debug APK
-      run: dotnet publish MobileApp/MobileApp.csproj -c Debug -f net9.0-android /p:AndroidPackageFormat=apk
+      run: dotnet publish MobileApp/MobileApp.csproj -c Debug -f net8.0-android /p:AndroidPackageFormat=apk
 
     - name: Build Release Bundle
-      run: dotnet publish MobileApp/MobileApp.csproj -c Release -f net9.0-android /p:AndroidPackageFormat=aab
+      run: dotnet publish MobileApp/MobileApp.csproj -c Release -f net8.0-android /p:AndroidPackageFormat=aab
 
     - name: Upload Debug APK
       if: success()
       uses: actions/upload-artifact@v4
       with:
         name: app-debug-apk
-        path: MobileApp/bin/Debug/net9.0-android/publish/*.apk
+        path: MobileApp/bin/Debug/net8.0-android/publish/*.apk
 
     - name: Upload Release AAB
       if: success()
       uses: actions/upload-artifact@v4
       with:
         name: app-release-aab
-        path: MobileApp/bin/Release/net9.0-android/publish/*.aab
+        path: MobileApp/bin/Release/net8.0-android/publish/*.aab

--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '8.0.x'
       - name: Publish OfflineSyncFunction
         run: dotnet publish Backend/OfflineSyncFunction/OfflineSyncFunction.csproj -c Release -o offline_publish
       - name: Publish RedeemFunction

--- a/.github/workflows/azure-test.yml
+++ b/.github/workflows/azure-test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '8.0.x'
       - name: Publish OfflineSyncFunction
         run: dotnet publish Backend/OfflineSyncFunction/OfflineSyncFunction.csproj -c Release -o offline_publish
       - name: Publish RedeemFunction

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '8.0.x'
       - name: Run .NET tests
         run: dotnet test tests/dotnet/Tests.csproj --verbosity normal
       - name: Setup Foundry

--- a/JapanTravelApp/JapanTravelApp.csproj
+++ b/JapanTravelApp/JapanTravelApp.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
     <PropertyGroup>
-        <TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
+        <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
         <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-        <!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
+        <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 
         <!-- Note for MacCatalyst:
             The default runtime is maccatalyst-x64, except in Release config, in which case the default is maccatalyst-x64;maccatalyst-arm64.
@@ -37,11 +37,11 @@
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">15.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">24.0</SupportedOSPlatformVersion>
-        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
-        <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
+        <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
+        <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</TargetPlatformMinVersion>
         <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
 
-        <MauiVersion>9.0.70</MauiVersion>
+        <MauiVersion>8.0.100</MauiVersion>
 
         <GenerateAppInstallerFile>True</GenerateAppInstallerFile>
 
@@ -63,37 +63,37 @@
         <!-- 他のプロパティ -->
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-android|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-android|AnyCPU'">
       <ApplicationId>jp.co.tonoi.japantravelapp</ApplicationId>
       <AndroidKeyStore>False</AndroidKeyStore>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-ios|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
       <ApplicationId>jp.co.tonoi.japantravelapp</ApplicationId>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-maccatalyst|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-maccatalyst|AnyCPU'">
       <ApplicationId>jp.co.tonoi.japantravelapp</ApplicationId>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net9.0-windows10.0.19041.0|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-windows10.0.19041.0|AnyCPU'">
       <ApplicationId>jp.co.tonoi.japantravelapp</ApplicationId>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-android|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-android|AnyCPU'">
       <ApplicationId>jp.co.tonoi.japantravelapp</ApplicationId>
       <AndroidKeyStore>False</AndroidKeyStore>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-ios|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
       <ApplicationId>jp.co.tonoi.japantravelapp</ApplicationId>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-maccatalyst|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-maccatalyst|AnyCPU'">
       <ApplicationId>jp.co.tonoi.japantravelapp</ApplicationId>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net9.0-windows10.0.19041.0|AnyCPU'">
+    <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-windows10.0.19041.0|AnyCPU'">
       <ApplicationId>jp.co.tonoi.japantravelapp</ApplicationId>
     </PropertyGroup>
 
@@ -127,14 +127,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.70" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="9.0.70" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="8.0.100" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Maui" Version="8.0.100" />
         <PackageReference Include="CommunityToolkit.Maui" Version="11.2.0" />
         <PackageReference Include="Plugin.LocalNotification" Version="12.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.5" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.0" />
         <!-- WindowsのみSystem.Drawing.Commonを参照 -->
-        <PackageReference Include="System.Drawing.Common" Version="9.0.5" Condition="'$(TargetFramework)' == 'net9.0-windows10.0.19041.0'" />
+        <PackageReference Include="System.Drawing.Common" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0-windows10.0.19041.0'" />
     </ItemGroup>
 
 </Project>

--- a/JapanTravelApp/Properties/PublishProfiles/MSIX-win-x64.pubxml
+++ b/JapanTravelApp/Properties/PublishProfiles/MSIX-win-x64.pubxml
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PublishDir>bin\Release\net9.0-windows10.0.19041.0\win10-x64\publish\</PublishDir>
+    <PublishDir>bin\Release\net8.0-windows10.0.19041.0\win10-x64\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <Platform>Any CPU</Platform>
     <Configuration>Release</Configuration>
-    <TargetFramework>net9.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <PublishSingleFile>false</PublishSingleFile>
     <PublishReadyToRun>false</PublishReadyToRun>
     <SelfContained>True</SelfContained>
     <PublishAppxPackage>true</PublishAppxPackage>
-    <AppxPackageDir>bin\Release\net9.0-windows10.0.19041.0\win10-x64\AppPackages\</AppxPackageDir>
+    <AppxPackageDir>bin\Release\net8.0-windows10.0.19041.0\win10-x64\AppPackages\</AppxPackageDir>
   </PropertyGroup>
 </Project>

--- a/MobileApp/MobileApp.csproj
+++ b/MobileApp/MobileApp.csproj
@@ -31,7 +31,7 @@
     <!-- Web3／WalletConnect -->
     <PackageReference Include="WalletConnect.Core" Version="2.4.3" />
 
-    <!-- NFC 代替プラグイン (.NET 9 対応) -->
+    <!-- NFC 代替プラグイン (.NET 8 対応) -->
     <PackageReference Include="TRNSPRNT.NFC" Version="1.2.0" />
 
     <!-- Ethereum -->

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## Build
 
 ```bash
-# .NET 9 と Node 20 が必要
+# .NET 8 と Node 20 が必要
 dotnet restore
 dotnet build MobileApp/MobileApp.csproj -t:Run
 ```

--- a/docs/device-testing.md
+++ b/docs/device-testing.md
@@ -1,7 +1,7 @@
 # Device Testing Guide
 
 ## Android Studio でビルド
-1. .NET 9 SDK と MAUI Android ワークロードをインストールします。
+1. .NET 8 SDK と MAUI Android ワークロードをインストールします。
    ```bash
    dotnet workload install maui-android
    ```
@@ -9,21 +9,21 @@
 3. `Run` ボタンを押すと、接続済みデバイスまたはエミュレーター上でアプリがビルドされます。
    CLI から実行する場合は次を使用します。
    ```bash
-   dotnet build MobileApp/MobileApp.csproj -t:Run -f net9.0-android
+   dotnet build MobileApp/MobileApp.csproj -t:Run -f net8.0-android
    ```
 
 ## Xcode でビルド
-1. macOS 上で .NET 9 SDK と MAUI iOS ワークロードをインストールします。
+1. macOS 上で .NET 8 SDK と MAUI iOS ワークロードをインストールします。
    ```bash
    dotnet workload install maui-ios
    ```
 2. ターミナルで iOS ビルドを生成します。
    ```bash
-   dotnet build MobileApp/MobileApp.csproj -f net9.0-ios
+   dotnet build MobileApp/MobileApp.csproj -f net8.0-ios
    ```
-3. 生成された `bin/Debug/net9.0-ios` 内の `.app` を Xcode の Simulator で開きます。
+3. 生成された `bin/Debug/net8.0-ios` 内の `.app` を Xcode の Simulator で開きます。
    ```bash
-   open bin/Debug/net9.0-ios/iossimulator/MobileApp.app
+   open bin/Debug/net8.0-ios/iossimulator/MobileApp.app
    ```
 
 ## 生体認証のテスト

--- a/tests/dotnet/Tests.csproj
+++ b/tests/dotnet/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
## Summary
- update docs and workflows to target .NET 8
- downgrade JapanTravelApp project from .NET 9 to .NET 8
- update dependencies and publish profile for Windows 19041
- adjust MAUI comment in MobileApp
- switch test project to .NET 8

## Testing
- `dotnet test tests/dotnet/Tests.csproj`
- `dotnet build JapanTravelApp/JapanTravelApp.csproj -c Debug -f net8.0-windows10.0.19041.0` *(fails: NETSDK1147 workload install)*
- `forge build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fc955ca08320953dbac58403c643