### PR TITLE
Add language menu and resource strings

### DIFF
--- a/MobileApp/Pages/CreateAlarm.razor
+++ b/MobileApp/Pages/CreateAlarm.razor
@@ -9,29 +9,29 @@
         
         <div class="alarm-form">
             <div class="form-group">
-                <label for="title">Title</label>
-                <input type="text" id="title" @bind="alarmTitle" class="form-control" placeholder="Enter alarm title" />
+                <label for="title">@AppResources.AlarmTitle</label>
+                <input type="text" id="title" @bind="alarmTitle" class="form-control" placeholder="@AppResources.AlarmTitlePlaceholder" />
             </div>
             
             <div class="form-group">
-                <label for="message">Message</label>
-                <textarea id="message" @bind="alarmMessage" class="form-control" rows="3" placeholder="Enter alarm message"></textarea>
+                <label for="message">@AppResources.AlarmMessage</label>
+                <textarea id="message" @bind="alarmMessage" class="form-control" rows="3" placeholder="@AppResources.AlarmMessagePlaceholder"></textarea>
             </div>
             
             <div class="form-group">
-                <label for="date">Date</label>
+                <label for="date">@AppResources.AlarmDate</label>
                 <input type="date" id="date" @bind="alarmDate" @bind:format="yyyy-MM-dd" class="form-control" />
             </div>
             
             <div class="form-group">
-                <label for="time">Time</label>
+                <label for="time">@AppResources.AlarmTime</label>
                 <input type="time" id="time" @bind="alarmTime" @bind:format="HH:mm" class="form-control" />
             </div>
             
             <div class="form-group">
                 <label class="checkbox-label">
                     <input type="checkbox" @bind="isRepeating" />
-                    Repeat Daily
+                    @AppResources.RepeatDaily
                 </label>
             </div>
             
@@ -41,9 +41,9 @@
                     {
                         <span class="spinner-border spinner-border-sm" role="status"></span>
                     }
-                    Create Alarm
+                    @AppResources.CreateAlarm
                 </button>
-                <button class="btn btn-secondary" @onclick="GoBack">Cancel</button>
+                <button class="btn btn-secondary" @onclick="GoBack">@AppResources.Cancel</button>
             </div>
         </div>
         
@@ -55,17 +55,17 @@
         @if (activeAlarms.Any())
         {
             <div class="active-alarms">
-                <h3>Active Alarms</h3>
+                <h3>@AppResources.ActiveAlarms</h3>
                 @foreach (var alarm in activeAlarms)
                 {
                     <div class="alarm-item">
                         <div class="alarm-info">
                             <h4>@alarm.Title</h4>
                             <p>@alarm.Message</p>
-                            <p><strong>Time:</strong> @alarm.ScheduledTime.ToString("yyyy/MM/dd HH:mm")</p>
-                            <p><strong>Repeating:</strong> @(alarm.IsRepeating ? "Yes" : "No")</p>
+                            <p><strong>@AppResources.AlarmTime:</strong> @alarm.ScheduledTime.ToString("yyyy/MM/dd HH:mm")</p>
+                            <p><strong>@AppResources.Repeating:</strong> @(alarm.IsRepeating ? @AppResources.Yes : @AppResources.No)</p>
                         </div>
-                        <button class="btn btn-danger btn-sm" @onclick="() => CancelAlarm(alarm.Id)">Cancel</button>
+                        <button class="btn btn-danger btn-sm" @onclick="() => CancelAlarm(alarm.Id)">@AppResources.Cancel</button>
                     </div>
                 }
             </div>

--- a/MobileApp/Pages/Passcode.razor
+++ b/MobileApp/Pages/Passcode.razor
@@ -1,9 +1,9 @@
 @page "/passcode"
 
 <div style="padding: 30px;">
-    <h1 style="font-size: 24px;">Enter Passcode</h1>
+    <h1 style="font-size: 24px;">@AppResources.EnterPasscode</h1>
     <input @bind-value="code" type="password" />
-    <button @onclick="@OnSubmit">Submit</button>
+    <button @onclick="@OnSubmit">@AppResources.Submit</button>
 </div>
 
 @code {

--- a/MobileApp/Pages/SignUp.razor
+++ b/MobileApp/Pages/SignUp.razor
@@ -1,10 +1,10 @@
 @page "/signup"
 
 <div style="padding: 30px;">
-    <h1 style="font-size: 24px;">Create Account</h1>
-    <input placeholder="Username" @bind-value="username" />
-    <input placeholder="Password" type="password" @bind-value="password" />
-    <button @onclick="OnSubmit">Sign Up</button>
+    <h1 style="font-size: 24px;">@AppResources.CreateAccount</h1>
+    <input placeholder="@AppResources.Username" @bind-value="username" />
+    <input placeholder="@AppResources.Password" type="password" @bind-value="password" />
+    <button @onclick="OnSubmit">@AppResources.SignUp</button>
 </div>
 
 @code {

--- a/MobileApp/Pages/TravelSettings.razor
+++ b/MobileApp/Pages/TravelSettings.razor
@@ -1,6 +1,5 @@
 @page "/travel-settings"
 @using JPYCOffline.Services.Travel
-@inject ILocalizationService LocalizationService
 @inject NavigationManager Navigation
 
 <div class="settings-container">
@@ -9,19 +8,6 @@
     </div>
 
     <div class="settings-content">
-        <!-- Language Settings -->
-        <div class="settings-section">
-            <h3>@AppResources.Language</h3>
-            <div class="setting-item">
-                <label>言語 / Language:</label>
-                <select @onchange="ChangeLanguage" class="form-control">
-                    <option value="en">English</option>
-                    <option value="ja">日本語</option>
-                    <option value="fr">Français</option>
-                    <option value="ko">한국어</option>
-                </select>
-            </div>
-        </div>
 
         <!-- Notification Settings -->
         <div class="settings-section">
@@ -73,16 +59,6 @@
 </div>
 
 @code {
-    private void ChangeLanguage(ChangeEventArgs e)
-    {
-        var culture = e.Value?.ToString();
-        if (!string.IsNullOrEmpty(culture))
-        {
-            LocalizationService.SetCulture(culture);
-            Navigation.NavigateTo(Navigation.Uri, forceLoad: true);
-        }
-    }
-
     private void NavigateToCreateAlarm()
     {
         Navigation.NavigateTo("/create-alarm");

--- a/MobileApp/Resources/Localizations/AppResources.fr.resx
+++ b/MobileApp/Resources/Localizations/AppResources.fr.resx
@@ -143,6 +143,56 @@
   <data name="CreateAlarm" xml:space="preserve">
     <value>Créer une alarme</value>
   </data>
+
+  <!-- Alarm Page -->
+  <data name="AlarmTitle" xml:space="preserve">
+    <value>Titre</value>
+  </data>
+  <data name="AlarmTitlePlaceholder" xml:space="preserve">
+    <value>Entrez le titre de l'alarme</value>
+  </data>
+  <data name="AlarmMessage" xml:space="preserve">
+    <value>Message</value>
+  </data>
+  <data name="AlarmMessagePlaceholder" xml:space="preserve">
+    <value>Saisissez le message de l'alarme</value>
+  </data>
+  <data name="AlarmDate" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="AlarmTime" xml:space="preserve">
+    <value>Heure</value>
+  </data>
+  <data name="RepeatDaily" xml:space="preserve">
+    <value>Répéter quotidiennement</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="ActiveAlarms" xml:space="preserve">
+    <value>Alarmes actives</value>
+  </data>
+  <data name="Repeating" xml:space="preserve">
+    <value>Répétition</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Oui</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>Non</value>
+  </data>
+  <data name="EnterPasscode" xml:space="preserve">
+    <value>Entrez le code</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Valider</value>
+  </data>
+  <data name="CreateAccount" xml:space="preserve">
+    <value>Créer un compte</value>
+  </data>
+  <data name="SignUp" xml:space="preserve">
+    <value>S'inscrire</value>
+  </data>
   
   <!-- General -->
   <data name="WelcomeToJapan" xml:space="preserve">

--- a/MobileApp/Resources/Localizations/AppResources.ja.resx
+++ b/MobileApp/Resources/Localizations/AppResources.ja.resx
@@ -143,6 +143,56 @@
   <data name="CreateAlarm" xml:space="preserve">
     <value>アラーム作成</value>
   </data>
+
+  <!-- Alarm Page -->
+  <data name="AlarmTitle" xml:space="preserve">
+    <value>タイトル</value>
+  </data>
+  <data name="AlarmTitlePlaceholder" xml:space="preserve">
+    <value>アラームのタイトルを入力</value>
+  </data>
+  <data name="AlarmMessage" xml:space="preserve">
+    <value>メッセージ</value>
+  </data>
+  <data name="AlarmMessagePlaceholder" xml:space="preserve">
+    <value>アラームのメッセージを入力</value>
+  </data>
+  <data name="AlarmDate" xml:space="preserve">
+    <value>日付</value>
+  </data>
+  <data name="AlarmTime" xml:space="preserve">
+    <value>時間</value>
+  </data>
+  <data name="RepeatDaily" xml:space="preserve">
+    <value>毎日繰り返す</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+  <data name="ActiveAlarms" xml:space="preserve">
+    <value>作動中のアラーム</value>
+  </data>
+  <data name="Repeating" xml:space="preserve">
+    <value>繰り返し</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>はい</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>いいえ</value>
+  </data>
+  <data name="EnterPasscode" xml:space="preserve">
+    <value>パスコードを入力</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>送信</value>
+  </data>
+  <data name="CreateAccount" xml:space="preserve">
+    <value>アカウント作成</value>
+  </data>
+  <data name="SignUp" xml:space="preserve">
+    <value>登録</value>
+  </data>
   
   <!-- General -->
   <data name="WelcomeToJapan" xml:space="preserve">

--- a/MobileApp/Resources/Localizations/AppResources.ko.resx
+++ b/MobileApp/Resources/Localizations/AppResources.ko.resx
@@ -143,6 +143,56 @@
   <data name="CreateAlarm" xml:space="preserve">
     <value>알람 생성</value>
   </data>
+
+  <!-- Alarm Page -->
+  <data name="AlarmTitle" xml:space="preserve">
+    <value>제목</value>
+  </data>
+  <data name="AlarmTitlePlaceholder" xml:space="preserve">
+    <value>알람 제목 입력</value>
+  </data>
+  <data name="AlarmMessage" xml:space="preserve">
+    <value>메시지</value>
+  </data>
+  <data name="AlarmMessagePlaceholder" xml:space="preserve">
+    <value>알람 메시지 입력</value>
+  </data>
+  <data name="AlarmDate" xml:space="preserve">
+    <value>날짜</value>
+  </data>
+  <data name="AlarmTime" xml:space="preserve">
+    <value>시간</value>
+  </data>
+  <data name="RepeatDaily" xml:space="preserve">
+    <value>매일 반복</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>취소</value>
+  </data>
+  <data name="ActiveAlarms" xml:space="preserve">
+    <value>활성 알람</value>
+  </data>
+  <data name="Repeating" xml:space="preserve">
+    <value>반복</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>예</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>아니오</value>
+  </data>
+  <data name="EnterPasscode" xml:space="preserve">
+    <value>암호 입력</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>제출</value>
+  </data>
+  <data name="CreateAccount" xml:space="preserve">
+    <value>계정 만들기</value>
+  </data>
+  <data name="SignUp" xml:space="preserve">
+    <value>가입하기</value>
+  </data>
   
   <!-- General -->
   <data name="WelcomeToJapan" xml:space="preserve">

--- a/MobileApp/Resources/Localizations/AppResources.resx
+++ b/MobileApp/Resources/Localizations/AppResources.resx
@@ -143,6 +143,56 @@
   <data name="CreateAlarm" xml:space="preserve">
     <value>Create Alarm</value>
   </data>
+
+  <!-- Alarm Page -->
+  <data name="AlarmTitle" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="AlarmTitlePlaceholder" xml:space="preserve">
+    <value>Enter alarm title</value>
+  </data>
+  <data name="AlarmMessage" xml:space="preserve">
+    <value>Message</value>
+  </data>
+  <data name="AlarmMessagePlaceholder" xml:space="preserve">
+    <value>Enter alarm message</value>
+  </data>
+  <data name="AlarmDate" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="AlarmTime" xml:space="preserve">
+    <value>Time</value>
+  </data>
+  <data name="RepeatDaily" xml:space="preserve">
+    <value>Repeat Daily</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="ActiveAlarms" xml:space="preserve">
+    <value>Active Alarms</value>
+  </data>
+  <data name="Repeating" xml:space="preserve">
+    <value>Repeating</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Yes</value>
+  </data>
+  <data name="No" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="EnterPasscode" xml:space="preserve">
+    <value>Enter Passcode</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Submit</value>
+  </data>
+  <data name="CreateAccount" xml:space="preserve">
+    <value>Create Account</value>
+  </data>
+  <data name="SignUp" xml:space="preserve">
+    <value>Sign Up</value>
+  </data>
   
   <!-- General -->
   <data name="WelcomeToJapan" xml:space="preserve">

--- a/MobileApp/Shared/MainLayout.razor
+++ b/MobileApp/Shared/MainLayout.razor
@@ -2,6 +2,7 @@
 @using JPYCOffline.Services.Travel
 @inject IAuthenticationService AuthService
 @inject NavigationManager Navigation
+@inject ILocalizationService LocalizationService
 
 <div class="page">
     <div class="sidebar">
@@ -23,6 +24,15 @@
             @if (showProfileMenu)
             {
                 <div class="profile-popup">
+                    <div class="profile-menu-item language-item">
+                        <i class="bi bi-translate"></i>
+                        <select @onchange="ChangeLanguage" value="@LocalizationService.GetCurrentCulture()" class="language-select">
+                            @foreach (var culture in LocalizationService.GetSupportedCultures())
+                            {
+                                <option value="@culture.Name">@culture.NativeName</option>
+                            }
+                        </select>
+                    </div>
                     <div class="profile-menu-item" @onclick="NavigateToAccountSettings">
                         <i class="bi bi-gear"></i> @AppResources.AccountSettings
                     </div>
@@ -54,6 +64,17 @@
     {
         showProfileMenu = false;
         Navigation.NavigateTo("/account-settings");
+    }
+
+    private void ChangeLanguage(ChangeEventArgs e)
+    {
+        var culture = e.Value?.ToString();
+        if (!string.IsNullOrEmpty(culture))
+        {
+            LocalizationService.SetCulture(culture);
+            showProfileMenu = false;
+            Navigation.NavigateTo(Navigation.Uri, forceLoad: true);
+        }
     }
 }
 
@@ -115,5 +136,13 @@
     .profile-menu-item i {
         font-size: 16px;
         color: #666;
+    }
+
+    .language-select {
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        padding: 4px 8px;
+        font-size: 14px;
+        margin-left: auto;
     }
 </style>


### PR DESCRIPTION
## Summary
- externalize more UI strings for localization
- move language selector from Settings page into the profile menu
- update layout to support language dropdown
- localize Passcode, SignUp and Create Alarm pages

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a575551148320bfdbb49d988b5578