### PR TITLE
Remove windows target frameworks

### DIFF
--- a/MobileApp/MobileApp.csproj
+++ b/MobileApp/MobileApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>
-      net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0-windows10.0.19041.0
+      net8.0-android;net8.0-ios;net8.0-maccatalyst
     </TargetFrameworks>
     <RootNamespace>JPYCOffline</RootNamespace>
     <UseMaui>true</UseMaui>
@@ -17,11 +17,6 @@
     <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFramework.Contains('-windows'))">
-    <OutputType>WinExe</OutputType>
-    <UseWPF>true</UseWPF>
-    <WindowsPackageType>None</WindowsPackageType>
-  </PropertyGroup>
 
   <ItemGroup>
     <!-- UI ランタイム -->


### PR DESCRIPTION
## Summary
- fix build failure by removing unused `net8.0-windows` target from MobileApp

## Testing
- `dotnet test tests/dotnet/Tests.csproj` *(fails: `dotnet` not found)*
- `forge build` *(fails: `forge` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa5cbfcb4832093203f9dc0a8e398